### PR TITLE
Remove constraint inference warning in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,17 +36,6 @@ Or make use of [purescript-refractor][purescript-refractor], which has predefine
 
 ----------
 
-### Warning
-Currently, [PureScript][PureScript] doesn't infer constraints [#202][#202].
-If you can fix it, please help out with it.
-
-What this means for you is that you sometimes have to annotate your lens/prism/traversal/whatever with a type.
-This might sound or look hairy, 
-but the most of the types aren't that hard to figure out and it'll go quite a way to show you that there's no magic going on in this library.
-They're all just type synonyms actually.
-
-----------
-
 There are two main types in this library: `Lens` and `Prism`.
 Both propose a way for "getting" and "setting" values in a data type.
 `Lens` is for working with product types (`Tuple`, records, fields in a data type).


### PR DESCRIPTION
As of psc 0.8.3, this is no longer the case. :tada: 
